### PR TITLE
Fix build by implementing missing UI components

### DIFF
--- a/components/ui/Breadcrumbs.tsx
+++ b/components/ui/Breadcrumbs.tsx
@@ -1,1 +1,110 @@
-export { default } from '../ui/Breadcrumbs';
+import React, { useMemo } from 'react';
+import { Link, useLocation } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
+import { ChevronRight } from 'lucide-react';
+import { ROUTES } from '../../config/routes';
+
+type BreadcrumbConfig = Record<string, string>;
+
+const BREADCRUMB_LABELS: BreadcrumbConfig = {
+  [ROUTES.director.dashboard]: 'navigation.director.dashboard',
+  [ROUTES.director.users]: 'navigation.director.users',
+  [ROUTES.director.enrollment]: 'navigation.director.enrollment',
+  [ROUTES.director.academic]: 'navigation.director.academic',
+  [ROUTES.director.academicProgress]: 'navigation.director.academicProgress',
+  [ROUTES.director.courseMonitoring]: 'navigation.director.courseMonitoring',
+  [ROUTES.director.studentMonitoring]: 'navigation.director.studentMonitoring',
+  [ROUTES.director.certificates]: 'navigation.director.certificates',
+  [ROUTES.director.downloads]: 'navigation.director.downloads',
+  [ROUTES.director.academicSettings]: 'navigation.director.academicSettings',
+  [ROUTES.director.attendance]: 'navigation.director.attendance',
+  [ROUTES.director.attendanceScanner]: 'navigation.director.attendanceScanner',
+  [ROUTES.director.communications]: 'navigation.director.communications',
+  [ROUTES.director.reports]: 'navigation.director.reports',
+  [ROUTES.director.resources]: 'navigation.director.resources',
+  [ROUTES.director.admin]: 'navigation.director.admin',
+  [ROUTES.director.settings]: 'navigation.director.settings',
+  [ROUTES.director.roles]: 'navigation.director.roles',
+  [ROUTES.director.activityLog]: 'navigation.director.activityLog',
+  [ROUTES.director.help]: 'navigation.director.help',
+  [ROUTES.director.coexistence]: 'navigation.director.coexistence',
+};
+
+const formatFallbackLabel = (path: string) => {
+  const segments = path.split('/').filter(Boolean);
+  const lastSegment = segments[segments.length - 1] || '';
+
+  return decodeURIComponent(lastSegment)
+    .replace(/-/g, ' ')
+    .replace(/\b\p{L}/gu, (match) => match.toUpperCase());
+};
+
+interface BreadcrumbItem {
+  path: string;
+  label: string;
+}
+
+const Breadcrumbs: React.FC = () => {
+  const location = useLocation();
+  const { t } = useTranslation();
+
+  const breadcrumbs = useMemo(() => {
+    const normalizedPath = location.pathname.replace(/\/+$/, '') || '/';
+    const segments = normalizedPath.split('/').filter(Boolean);
+    const cumulativePaths = segments.map((_, index) => `/${segments.slice(0, index + 1).join('/')}`);
+    const allPaths = ['/', ...cumulativePaths];
+    const uniquePaths = Array.from(new Set(allPaths));
+
+    return uniquePaths
+      .map<BreadcrumbItem | null>((path) => {
+        const labelKey = BREADCRUMB_LABELS[path];
+        const label = labelKey ? t(labelKey) : formatFallbackLabel(path);
+
+        if (!label) {
+          return null;
+        }
+
+        return { path, label };
+      })
+      .filter((item): item is BreadcrumbItem => Boolean(item));
+  }, [location.pathname, t]);
+
+  if (breadcrumbs.length <= 1) {
+    return null;
+  }
+
+  return (
+    <nav aria-label="Breadcrumb" className="mb-6" data-testid="breadcrumbs">
+      <ol className="flex flex-wrap items-center gap-1 text-sm text-slate-500 dark:text-slate-400">
+        {breadcrumbs.map((crumb, index) => {
+          const isLast = index === breadcrumbs.length - 1;
+
+          return (
+            <li key={crumb.path} className="flex items-center">
+              {index > 0 && (
+                <ChevronRight
+                  aria-hidden="true"
+                  className="mx-2 h-4 w-4 text-slate-400 dark:text-slate-600"
+                />
+              )}
+              {isLast ? (
+                <span className="font-semibold text-slate-600 dark:text-slate-200" aria-current="page">
+                  {crumb.label}
+                </span>
+              ) : (
+                <Link
+                  to={crumb.path}
+                  className="transition-colors hover:text-indigo-600 dark:hover:text-indigo-400"
+                >
+                  {crumb.label}
+                </Link>
+              )}
+            </li>
+          );
+        })}
+      </ol>
+    </nav>
+  );
+};
+
+export default Breadcrumbs;

--- a/components/ui/Calendar.tsx
+++ b/components/ui/Calendar.tsx
@@ -1,1 +1,137 @@
-export { default } from '../ui/Calendar';
+import React, { useMemo } from 'react';
+import {
+  addDays,
+  eachDayOfInterval,
+  endOfMonth,
+  endOfWeek,
+  format,
+  isSameDay,
+  isSameMonth,
+  isToday,
+  startOfMonth,
+  startOfWeek,
+} from 'date-fns';
+import es from 'date-fns/locale/es';
+import { CalendarEvent } from '../../types';
+import { eventCategoryColors } from '../../config';
+
+interface CalendarProps {
+  currentDate: Date;
+  selectedDate: Date;
+  onSelectDate: (date: Date) => void;
+  events: CalendarEvent[];
+}
+
+const buildClassName = (classes: string[]) => classes.filter(Boolean).join(' ');
+
+const Calendar: React.FC<CalendarProps> = ({ currentDate, selectedDate, onSelectDate, events }) => {
+  const start = startOfWeek(startOfMonth(currentDate), { weekStartsOn: 1 });
+  const end = endOfWeek(endOfMonth(currentDate), { weekStartsOn: 1 });
+
+  const days = eachDayOfInterval({ start, end });
+
+  const weekDays = useMemo(
+    () =>
+      Array.from({ length: 7 }, (_, index) =>
+        format(addDays(startOfWeek(new Date(), { weekStartsOn: 1 }), index), 'EEEEEE', {
+          locale: es,
+        }).toUpperCase(),
+      ),
+    [],
+  );
+
+  const eventsByDate = useMemo(() => {
+    return events.reduce<Record<string, CalendarEvent[]>>((accumulator, event) => {
+      const dateKey = event.date;
+      if (!accumulator[dateKey]) {
+        accumulator[dateKey] = [];
+      }
+      accumulator[dateKey].push(event);
+      return accumulator;
+    }, {});
+  }, [events]);
+
+  return (
+    <div className="rounded-2xl border border-slate-200/80 dark:border-slate-700/60 bg-white dark:bg-slate-900 p-4">
+      <div className="grid grid-cols-7 gap-2 text-center text-xs font-semibold uppercase tracking-wide text-slate-400 dark:text-slate-500">
+        {weekDays.map((weekDay) => (
+          <span key={weekDay}>{weekDay}</span>
+        ))}
+      </div>
+      <div className="mt-2 grid grid-cols-7 gap-2">
+        {days.map((day) => {
+          const dateKey = format(day, 'yyyy-MM-dd');
+          const dayEvents = eventsByDate[dateKey] || [];
+          const isSelected = isSameDay(day, selectedDate);
+          const inCurrentMonth = isSameMonth(day, currentDate);
+          const today = isToday(day);
+          const additionalCount = Math.max(0, dayEvents.length - 3);
+
+          const dayClasses = buildClassName([
+            'aspect-square',
+            'w-full',
+            'rounded-xl',
+            'border',
+            'border-transparent',
+            'p-2',
+            'flex',
+            'flex-col',
+            'items-center',
+            'justify-between',
+            'text-sm',
+            'transition-all',
+            'duration-150',
+            'focus:outline-none',
+            'focus-visible:ring-2',
+            'focus-visible:ring-indigo-500',
+            'focus-visible:ring-offset-2',
+            'focus-visible:ring-offset-white',
+            'dark:focus-visible:ring-offset-slate-900',
+            inCurrentMonth ? 'text-slate-700 dark:text-slate-200' : 'text-slate-400 dark:text-slate-500',
+            today && !isSelected ? 'border-indigo-300 dark:border-indigo-500/60' : '',
+            isSelected
+              ? 'bg-indigo-600 text-white shadow-lg'
+              : 'hover:border-indigo-200 dark:hover:border-indigo-500/50',
+          ]);
+
+          const eventLabel = dayEvents.length
+            ? `Eventos: ${dayEvents.map((event) => event.title).join(', ')}`
+            : 'Sin eventos';
+
+          return (
+            <button
+              key={dateKey}
+              type="button"
+              className={dayClasses}
+              onClick={() => onSelectDate(day)}
+              aria-pressed={isSelected}
+              aria-label={`${format(day, 'd MMMM yyyy', { locale: es })}. ${eventLabel}`}
+            >
+              <span className="font-semibold">{format(day, 'd')}</span>
+              <div className="flex flex-wrap justify-center gap-1">
+                {dayEvents.slice(0, 3).map((event) => (
+                  <span
+                    key={event.id}
+                    className={buildClassName([
+                      'h-1.5',
+                      'w-1.5',
+                      'rounded-full',
+                      eventCategoryColors[event.category] || 'bg-slate-400',
+                    ])}
+                    aria-hidden="true"
+                    title={event.title}
+                  />
+                ))}
+                {additionalCount > 0 ? (
+                  <span className="text-[10px] font-semibold text-slate-500 dark:text-slate-400">+{additionalCount}</span>
+                ) : null}
+              </div>
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+};
+
+export default Calendar;

--- a/components/ui/ConfirmDialog.tsx
+++ b/components/ui/ConfirmDialog.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import Button from './Button';
 import { AlertTriangle } from 'lucide-react';
-import { useFocusTrap } from '../hooks/useFocusTrap';
+import { useFocusTrap } from '../../hooks/useFocusTrap';
 
 interface ConfirmDialogProps {
   isOpen: boolean;

--- a/components/ui/Drawer.tsx
+++ b/components/ui/Drawer.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, ReactNode } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { X } from 'lucide-react';
-import { useFocusTrap } from '../hooks/useFocusTrap';
+import { useFocusTrap } from '../../hooks/useFocusTrap';
 
 interface DrawerProps {
   isOpen: boolean;

--- a/components/ui/DynamicChart.tsx
+++ b/components/ui/DynamicChart.tsx
@@ -1,1 +1,103 @@
-export { default } from '../ui/DynamicChart';
+import React, { useMemo } from 'react';
+import {
+  ResponsiveContainer,
+  LineChart,
+  Line,
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  Tooltip,
+  CartesianGrid,
+  Legend,
+} from 'recharts';
+
+interface DynamicChartProps {
+  title: string;
+  data: Array<Record<string, number | string>>;
+  dataKeys: string[];
+  nameKey?: string;
+  chartType?: 'line' | 'bar';
+  colorPalette?: string[];
+}
+
+const DEFAULT_COLORS = ['#4f46e5', '#f97316', '#14b8a6', '#facc15'];
+
+const tooltipStyle: React.CSSProperties = {
+  backgroundColor: 'rgba(15, 23, 42, 0.95)',
+  color: '#f8fafc',
+  borderRadius: '0.75rem',
+  border: '1px solid rgba(148, 163, 184, 0.35)',
+  padding: '0.75rem 1rem',
+};
+
+const axisStyle = {
+  stroke: '#94a3b8',
+  fontSize: 12,
+};
+
+const gridColor = 'rgba(148, 163, 184, 0.2)';
+
+const DynamicChart: React.FC<DynamicChartProps> = ({
+  title,
+  data,
+  dataKeys,
+  nameKey = 'name',
+  chartType,
+  colorPalette = DEFAULT_COLORS,
+}) => {
+  const effectiveChartType = useMemo(() => {
+    if (chartType) {
+      return chartType;
+    }
+
+    if (dataKeys.length === 1 && dataKeys[0] === 'value') {
+      return 'bar';
+    }
+
+    return 'line';
+  }, [chartType, dataKeys]);
+
+  if (!data || data.length === 0) {
+    return (
+      <div className="h-64 rounded-2xl border border-slate-200/80 dark:border-slate-700/60 bg-white dark:bg-slate-900 p-6 flex items-center justify-center">
+        <p className="text-sm text-slate-500 dark:text-slate-400">Sin datos disponibles</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="h-64 rounded-2xl border border-slate-200/80 dark:border-slate-700/60 bg-white dark:bg-slate-900 p-4">
+      <header className="mb-4">
+        <h3 className="text-lg font-semibold text-slate-800 dark:text-slate-100">{title}</h3>
+      </header>
+      <ResponsiveContainer width="100%" height="calc(100% - 1.5rem)">
+        {effectiveChartType === 'line' ? (
+          <LineChart data={data}>
+            <CartesianGrid stroke={gridColor} strokeDasharray="3 3" />
+            <XAxis dataKey={nameKey} stroke={axisStyle.stroke} tick={{ fontSize: axisStyle.fontSize, fill: axisStyle.stroke }} tickLine={false} axisLine={false} />
+            <YAxis stroke={axisStyle.stroke} tick={{ fontSize: axisStyle.fontSize, fill: axisStyle.stroke }} tickLine={false} axisLine={false} allowDecimals />
+            <Tooltip contentStyle={tooltipStyle} cursor={{ stroke: '#6366f1', strokeWidth: 1 }} />
+            <Legend wrapperStyle={{ color: '#1e293b' }} />
+            {dataKeys.map((key, index) => (
+              <Line key={key} type="monotone" dataKey={key} stroke={colorPalette[index % colorPalette.length]} strokeWidth={2.5} dot={{ strokeWidth: 2, r: 4 }} activeDot={{ r: 6 }} />
+            ))}
+          </LineChart>
+        ) : (
+          <BarChart data={data}>
+            <CartesianGrid stroke={gridColor} strokeDasharray="3 3" />
+            <XAxis dataKey={nameKey} stroke={axisStyle.stroke} tick={{ fontSize: axisStyle.fontSize, fill: axisStyle.stroke }} tickLine={false} axisLine={false} />
+            <YAxis stroke={axisStyle.stroke} tick={{ fontSize: axisStyle.fontSize, fill: axisStyle.stroke }} tickLine={false} axisLine={false} />
+            <Tooltip contentStyle={tooltipStyle} cursor={{ fill: 'rgba(99, 102, 241, 0.12)' }} />
+            <Legend wrapperStyle={{ color: '#1e293b' }} />
+            {dataKeys.map((key, index) => (
+              <Bar key={key} dataKey={key} fill={colorPalette[index % colorPalette.length]} radius={[12, 12, 12, 12]} barSize={28} />
+            ))}
+          </BarChart>
+        )}
+      </ResponsiveContainer>
+    </div>
+  );
+};
+
+export default DynamicChart;

--- a/components/ui/KpiCard.tsx
+++ b/components/ui/KpiCard.tsx
@@ -1,1 +1,115 @@
-export { default } from '../ui/KpiCard';
+import React from 'react';
+import type { LucideIcon } from 'lucide-react';
+
+type KpiCardVariant = 'default' | 'gradient';
+
+interface KpiCardProps {
+  title: string;
+  value: string | number;
+  icon: LucideIcon;
+  description?: string;
+  variant?: KpiCardVariant;
+  color?: string;
+  active?: boolean;
+  onClick?: () => void;
+  className?: string;
+}
+
+const buildClassName = (classes: string[]) => classes.filter(Boolean).join(' ');
+
+const KpiCard: React.FC<KpiCardProps> = ({
+  title,
+  value,
+  icon: Icon,
+  description,
+  variant = 'default',
+  color,
+  active = false,
+  onClick,
+  className,
+}) => {
+  const isGradient = variant === 'gradient';
+  const Tag = (onClick ? 'button' : 'div') as 'button' | 'div';
+
+  const containerClassName = buildClassName([
+    'rounded-2xl',
+    'p-5',
+    'flex',
+    'flex-col',
+    'gap-3',
+    'transition-all',
+    'duration-200',
+    'shadow-sm',
+    'hover:shadow-lg',
+    onClick ? 'cursor-pointer hover:-translate-y-1' : '',
+    isGradient
+      ? buildClassName([
+          'text-white',
+          'bg-gradient-to-br',
+          color || 'from-indigo-500 to-purple-600',
+          'shadow-lg',
+        ])
+      : 'bg-white dark:bg-slate-800 border border-slate-200/80 dark:border-slate-700/60',
+    active
+      ? isGradient
+        ? 'ring-2 ring-white/70 ring-offset-2 ring-offset-transparent'
+        : 'ring-2 ring-indigo-500 dark:ring-indigo-400'
+      : '',
+    onClick
+      ? buildClassName([
+          'focus:outline-none',
+          'focus-visible:ring-2',
+          'focus-visible:ring-indigo-500',
+          'focus-visible:ring-offset-2',
+          isGradient ? 'focus-visible:ring-offset-transparent' : 'focus-visible:ring-offset-white dark:focus-visible:ring-offset-slate-900',
+        ])
+      : '',
+    className || '',
+  ]);
+
+  const iconWrapperClassName = isGradient
+    ? 'w-12 h-12 rounded-xl bg-white/15 flex items-center justify-center text-white'
+    : 'w-12 h-12 rounded-xl bg-indigo-50 text-indigo-600 dark:bg-indigo-500/15 dark:text-indigo-300 flex items-center justify-center';
+
+  const valueClassName = buildClassName([
+    'text-3xl',
+    'font-bold',
+    isGradient ? 'text-white' : 'text-slate-800 dark:text-slate-100',
+  ]);
+
+  const titleClassName = buildClassName([
+    'text-sm',
+    'font-medium',
+    isGradient ? 'text-white/80' : 'text-slate-500 dark:text-slate-400',
+  ]);
+
+  const descriptionClassName = buildClassName([
+    'text-sm',
+    isGradient ? 'text-white/70' : 'text-slate-500 dark:text-slate-400',
+  ]);
+
+  const interactiveProps = onClick
+    ? ({
+        onClick,
+        type: 'button',
+        'aria-pressed': active,
+      } as const)
+    : ({} as const);
+
+  return (
+    <Tag className={containerClassName} {...interactiveProps}>
+      <div className="flex items-center justify-between">
+        <div className="flex flex-col gap-1">
+          <span className={titleClassName}>{title}</span>
+          <span className={valueClassName}>{value}</span>
+        </div>
+        <div className={iconWrapperClassName} aria-hidden="true">
+          <Icon size={28} />
+        </div>
+      </div>
+      {description ? <p className={descriptionClassName}>{description}</p> : null}
+    </Tag>
+  );
+};
+
+export default KpiCard;

--- a/components/ui/SearchBar.tsx
+++ b/components/ui/SearchBar.tsx
@@ -1,6 +1,6 @@
 import React, { useRef, useEffect } from 'react';
 import { Search } from 'lucide-react';
-import { useUIStore } from '../store/uiStore';
+import { useUIStore } from '../../store/uiStore';
 import Input from './Input';
 
 const SearchBar: React.FC = () => {

--- a/components/ui/Tag.tsx
+++ b/components/ui/Tag.tsx
@@ -1,1 +1,65 @@
-export { default } from '../ui/Tag';
+import React from 'react';
+import { X } from 'lucide-react';
+
+type TagVariant = 'default' | 'success' | 'warning' | 'danger' | 'info';
+
+interface TagProps {
+  children: React.ReactNode;
+  variant?: TagVariant;
+  icon?: React.ElementType;
+  onRemove?: () => void;
+  className?: string;
+  removableLabel?: string;
+}
+
+const VARIANT_STYLES: Record<TagVariant, string> = {
+  default: 'bg-slate-100 text-slate-700 dark:bg-slate-800/80 dark:text-slate-200',
+  success: 'bg-emerald-100 text-emerald-700 dark:bg-emerald-500/20 dark:text-emerald-200',
+  warning: 'bg-amber-100 text-amber-700 dark:bg-amber-500/20 dark:text-amber-200',
+  danger: 'bg-rose-100 text-rose-700 dark:bg-rose-500/20 dark:text-rose-200',
+  info: 'bg-indigo-100 text-indigo-700 dark:bg-indigo-500/20 dark:text-indigo-200',
+};
+
+const buildClassName = (classes: string[]) => classes.filter(Boolean).join(' ');
+
+const Tag: React.FC<TagProps> = ({
+  children,
+  variant = 'default',
+  icon: Icon,
+  onRemove,
+  className,
+  removableLabel = 'Quitar etiqueta',
+}) => {
+  const containerClassName = buildClassName([
+    'inline-flex',
+    'items-center',
+    'gap-1.5',
+    'rounded-full',
+    'px-3',
+    'py-1',
+    'text-sm',
+    'font-semibold',
+    VARIANT_STYLES[variant],
+    onRemove ? 'pr-2' : '',
+    className || '',
+  ]);
+
+  return (
+    <span className={containerClassName} data-variant={variant}>
+      {Icon ? <Icon size={14} className="shrink-0" aria-hidden="true" /> : null}
+      <span>{children}</span>
+      {onRemove ? (
+        <button
+          type="button"
+          onClick={onRemove}
+          className="ml-1 rounded-full p-1 transition-colors hover:bg-black/10 focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-1 focus-visible:ring-indigo-500 dark:hover:bg-white/10"
+          aria-label={removableLabel}
+        >
+          <X size={12} aria-hidden="true" />
+        </button>
+      ) : null}
+    </span>
+  );
+};
+
+export default Tag;


### PR DESCRIPTION
## Summary
- correct broken relative imports in shared UI components
- implement breadcrumb, KPI card, calendar, dynamic chart, and tag components that were previously self-referencing stubs
- ensure the new widgets handle accessibility details and theme variants while supporting existing feature usage

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68e0b072dea08329ab20d1f52193d893