### PR TITLE
Refactor user list header search experience

### DIFF
--- a/components/users/AutocompleteSuggestions.tsx
+++ b/components/users/AutocompleteSuggestions.tsx
@@ -3,31 +3,66 @@ import { motion, AnimatePresence } from 'framer-motion';
 import { GenericUser, Student } from '../../types';
 
 const isStudent = (user: GenericUser): user is Student => 'studentCode' in user;
-const getFullName = (user: GenericUser): string => isStudent(user) ? user.fullName : user.name;
 
 interface AutocompleteSuggestionsProps {
     suggestions: GenericUser[];
     activeSuggestionIndex: number;
     onSelectSuggestion: (suggestion: GenericUser) => void;
     inputValue: string;
+    suggestionListId: string;
+    optionIdPrefix: string;
+    getDisplayName: (user: GenericUser) => string;
 }
 
-const AutocompleteSuggestions: React.FC<AutocompleteSuggestionsProps> = ({ suggestions, activeSuggestionIndex, onSelectSuggestion, inputValue }) => {
-    
+const AutocompleteSuggestions: React.FC<AutocompleteSuggestionsProps> = ({
+    suggestions,
+    activeSuggestionIndex,
+    onSelectSuggestion,
+    inputValue,
+    suggestionListId,
+    optionIdPrefix,
+    getDisplayName,
+}) => {
     const highlightMatch = (text: string, query: string) => {
         if (!query) return text;
-        const parts = text.split(new RegExp(`(${query})`, 'gi'));
-        return (
-            <span>
-                {parts.map((part, i) =>
-                    part.toLowerCase() === query.toLowerCase() ? (
-                        <strong key={i} className="font-extrabold">{part}</strong>
-                    ) : (
-                        part
-                    )
-                )}
-            </span>
-        );
+
+        const lowerText = text.toLowerCase();
+        const lowerQuery = query.toLowerCase();
+        const queryLength = query.length;
+        const segments: React.ReactNode[] = [];
+        let currentIndex = 0;
+        let matchIndex = lowerText.indexOf(lowerQuery, currentIndex);
+        let segmentKey = 0;
+
+        while (matchIndex !== -1) {
+            if (matchIndex > currentIndex) {
+                segments.push(
+                    <React.Fragment key={`text-${segmentKey++}`}>
+                        {text.slice(currentIndex, matchIndex)}
+                    </React.Fragment>,
+                );
+            }
+
+            const matchText = text.slice(matchIndex, matchIndex + queryLength);
+            segments.push(
+                <strong key={`match-${segmentKey++}`} className="font-extrabold">
+                    {matchText}
+                </strong>,
+            );
+
+            currentIndex = matchIndex + queryLength;
+            matchIndex = lowerText.indexOf(lowerQuery, currentIndex);
+        }
+
+        if (currentIndex < text.length) {
+            segments.push(
+                <React.Fragment key={`text-${segmentKey++}`}>
+                    {text.slice(currentIndex)}
+                </React.Fragment>,
+            );
+        }
+
+        return <span>{segments}</span>;
     };
 
     return (
@@ -39,22 +74,31 @@ const AutocompleteSuggestions: React.FC<AutocompleteSuggestionsProps> = ({ sugge
                     exit={{ opacity: 0, y: -5 }}
                     className="absolute top-full w-full mt-2 bg-white dark:bg-slate-800 rounded-2xl shadow-lg border border-slate-200 dark:border-slate-700 z-50 overflow-hidden"
                 >
-                    <ul role="listbox">
+                    <ul
+                        id={suggestionListId}
+                        role="listbox"
+                        data-testid="userlist-suggestions"
+                    >
                         {suggestions.map((user, index) => {
-                            const fullName = getFullName(user);
+                            const displayName = getDisplayName(user);
+                            const optionId = `${optionIdPrefix}${index}`;
+
                             return (
                                 <li
                                     key={isStudent(user) ? user.documentNumber : user.dni}
+                                    id={optionId}
                                     role="option"
                                     aria-selected={index === activeSuggestionIndex}
                                     onClick={() => onSelectSuggestion(user)}
                                     className={`flex items-center gap-3 p-3 cursor-pointer transition-colors ${
-                                        index === activeSuggestionIndex ? 'bg-indigo-100 dark:bg-indigo-500/20' : 'hover:bg-slate-50 dark:hover:bg-slate-700/50'
+                                        index === activeSuggestionIndex
+                                            ? 'bg-indigo-100 dark:bg-indigo-500/20'
+                                            : 'hover:bg-slate-50 dark:hover:bg-slate-700/50'
                                     }`}
                                 >
-                                    <img src={user.avatarUrl} alt={fullName} className="w-9 h-9 rounded-full" />
+                                    <img src={user.avatarUrl} alt={displayName} className="w-9 h-9 rounded-full" />
                                     <span className="text-base text-slate-700 dark:text-slate-200 capitalize">
-                                        {highlightMatch(fullName.toLowerCase(), inputValue)}
+                                        {highlightMatch(displayName, inputValue)}
                                     </span>
                                 </li>
                             );

--- a/components/users/UserListHeader.tsx
+++ b/components/users/UserListHeader.tsx
@@ -1,94 +1,207 @@
 import React, { useState, useEffect, useCallback } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { Search, X, AlertTriangle } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
 import { GenericUser, Student, SearchTag } from '../../types';
 import AutocompleteSuggestions from './AutocompleteSuggestions';
 
 const isStudent = (user: GenericUser): user is Student => 'studentCode' in user;
-const getFullName = (user: GenericUser): string => isStudent(user) ? user.fullName : user.name;
+const getFullName = (user: GenericUser): string => (isStudent(user) ? user.fullName : user.name);
+
+const normalizeText = (text: string) =>
+    text
+        .normalize('NFD')
+        .replace(/[\u0300-\u036f]/g, '')
+        .toLowerCase();
+
+interface AriaLabelKeys {
+    addFilter?: string;
+    removeFilter?: string;
+}
 
 interface UserListHeaderProps {
     tags: SearchTag[];
     allUsers: GenericUser[];
     onAddTag: (value: string) => void;
     onRemoveTag: (value: string) => void;
+    minChars?: number;
+    suggestionLimit?: number;
+    gradePattern?: RegExp;
+    getDisplayName?: (user: GenericUser) => string;
+    placeholderKey?: string;
+    ariaLabels?: AriaLabelKeys;
+    loopNavigation?: boolean;
 }
 
-const UserListHeader: React.FC<UserListHeaderProps> = ({ tags, allUsers, onAddTag, onRemoveTag }) => {
+const SUGGESTION_LIST_ID = 'user-suggestions-list';
+const OPTION_ID_PREFIX = 'user-suggestion-';
+const DEBOUNCE_DELAY = 200;
+
+const UserListHeader: React.FC<UserListHeaderProps> = ({
+    tags,
+    allUsers,
+    onAddTag,
+    onRemoveTag,
+    minChars = 2,
+    suggestionLimit = 5,
+    gradePattern = /^\d{1,2}\s?[A-F]$/i,
+    getDisplayName = getFullName,
+    placeholderKey = 'ui.userListHeader.placeholder',
+    ariaLabels = {
+        addFilter: 'ui.userListHeader.aria.addFilter',
+        removeFilter: 'ui.userListHeader.aria.removeFilter',
+    },
+    loopNavigation = false,
+}) => {
+    const { t } = useTranslation();
     const [inputValue, setInputValue] = useState('');
+    const [debouncedValue, setDebouncedValue] = useState('');
     const [suggestions, setSuggestions] = useState<GenericUser[]>([]);
     const [activeSuggestionIndex, setActiveSuggestionIndex] = useState(-1);
 
+    const addFilterLabelKey = ariaLabels?.addFilter ?? 'ui.userListHeader.aria.addFilter';
+    const removeFilterLabelKey = ariaLabels?.removeFilter ?? 'ui.userListHeader.aria.removeFilter';
+
     const resetSearch = useCallback(() => {
         setInputValue('');
+        setDebouncedValue('');
         setSuggestions([]);
         setActiveSuggestionIndex(-1);
     }, []);
 
-    const handleAddTagAndReset = useCallback((tagValue: string) => {
-        if (tagValue.trim()) {
-            onAddTag(tagValue.trim());
-        }
-        resetSearch();
-    }, [onAddTag, resetSearch]);
+    const handleAddTagAndReset = useCallback(
+        (tagValue: string) => {
+            if (tagValue.trim()) {
+                onAddTag(tagValue.trim());
+            }
+            resetSearch();
+        },
+        [onAddTag, resetSearch],
+    );
 
     useEffect(() => {
-        if (inputValue.length > 1) {
-            const gradeRegex = /^\d{1,2}\s?[A-F]$/i;
-            if (gradeRegex.test(inputValue)) {
+        const handler = setTimeout(() => {
+            setDebouncedValue(inputValue);
+        }, DEBOUNCE_DELAY);
+
+        return () => clearTimeout(handler);
+    }, [inputValue]);
+
+    useEffect(() => {
+        const trimmedValue = debouncedValue.trim();
+
+        if (trimmedValue.length >= minChars) {
+            const gradeRegex = new RegExp(gradePattern);
+
+            if (gradeRegex.test(trimmedValue)) {
                 setSuggestions([]);
+                setActiveSuggestionIndex(-1);
                 return;
             }
 
-            const filteredSuggestions = allUsers.filter(user =>
-                getFullName(user).toLowerCase().includes(inputValue.toLowerCase())
-            ).slice(0, 5);
+            const normalizedQuery = normalizeText(trimmedValue);
+            const filteredSuggestions = allUsers
+                .filter((user) => normalizeText(getDisplayName(user)).includes(normalizedQuery))
+                .slice(0, Math.max(suggestionLimit, 0));
+
+            setActiveSuggestionIndex(-1);
             setSuggestions(filteredSuggestions);
         } else {
             setSuggestions([]);
+            setActiveSuggestionIndex(-1);
         }
-    }, [inputValue, allUsers]);
+    }, [debouncedValue, allUsers, minChars, suggestionLimit, gradePattern, getDisplayName]);
+
+    useEffect(() => {
+        if (suggestions.length === 0) {
+            setActiveSuggestionIndex(-1);
+            return;
+        }
+
+        setActiveSuggestionIndex((prev) => {
+            if (prev >= suggestions.length) {
+                return suggestions.length - 1;
+            }
+            return prev;
+        });
+    }, [suggestions]);
 
     const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
         if ((e.key === 'Enter' || e.key === 'Tab') && inputValue.trim()) {
             e.preventDefault();
             if (activeSuggestionIndex > -1 && suggestions[activeSuggestionIndex]) {
-                handleAddTagAndReset(getFullName(suggestions[activeSuggestionIndex]));
+                handleAddTagAndReset(getDisplayName(suggestions[activeSuggestionIndex]));
             } else {
                 handleAddTagAndReset(inputValue);
             }
-        } else if (e.key === 'ArrowDown') {
+            return;
+        }
+
+        if (e.key === 'ArrowDown') {
+            if (!suggestions.length) {
+                return;
+            }
             e.preventDefault();
-            setActiveSuggestionIndex(prev => Math.min(prev + 1, suggestions.length - 1));
-        } else if (e.key === 'ArrowUp') {
+            setActiveSuggestionIndex((prev) => {
+                const nextIndex = prev + 1;
+                if (nextIndex >= suggestions.length) {
+                    return loopNavigation ? 0 : suggestions.length - 1;
+                }
+                return nextIndex;
+            });
+            return;
+        }
+
+        if (e.key === 'ArrowUp') {
+            if (!suggestions.length) {
+                return;
+            }
             e.preventDefault();
-            setActiveSuggestionIndex(prev => Math.max(prev - 1, 0));
-        } else if (e.key === 'Escape') {
+            setActiveSuggestionIndex((prev) => {
+                if (prev <= -1) {
+                    return loopNavigation ? suggestions.length - 1 : -1;
+                }
+                const nextIndex = prev - 1;
+                if (nextIndex < 0) {
+                    return loopNavigation ? suggestions.length - 1 : -1;
+                }
+                return nextIndex;
+            });
+            return;
+        }
+
+        if (e.key === 'Escape') {
+            e.preventDefault();
             resetSearch();
         }
     };
 
     const isPlaceholderVisible = tags.length === 0 && !inputValue;
+    const placeholderText = t(placeholderKey);
+    const addFilterAriaLabel = t(addFilterLabelKey);
 
     return (
         <div className="relative">
-             <div 
+            <div
                 className="relative flex items-center w-full px-4 text-base border border-slate-200 dark:border-slate-600 rounded-full bg-white dark:bg-slate-700 dark:text-slate-100 focus-within:ring-2 focus-within:ring-indigo-500 transition min-h-[52px]"
             >
                 <Search className="text-slate-400 pointer-events-none" size={24} />
-                
-                <div className="relative flex-1 flex items-center flex-wrap gap-2 ml-3">
+
+                <div
+                    className="relative flex-1 flex items-center flex-wrap gap-2 ml-3"
+                    data-testid="userlist-tags"
+                >
                     <AnimatePresence>
                         {isPlaceholderVisible && (
                             <motion.div
                                 initial={{ opacity: 0, scale: 0.98 }}
                                 animate={{ opacity: 1, scale: 1 }}
                                 exit={{ opacity: 0, scale: 0.98 }}
-                                transition={{ duration: 0.2, ease: "easeOut" }}
+                                transition={{ duration: 0.2, ease: 'easeOut' }}
                                 aria-hidden="true"
                                 className="absolute inset-y-0 left-0 flex items-center text-slate-400 dark:text-slate-500 pointer-events-none"
                             >
-                                <span className="text-lg font-bold">Buscar (nombre, DNI, rol, grado: 5A)...</span>
+                                <span className="text-lg font-bold">{placeholderText}</span>
                             </motion.div>
                         )}
                     </AnimatePresence>
@@ -103,43 +216,59 @@ const UserListHeader: React.FC<UserListHeaderProps> = ({ tags, allUsers, onAddTa
                                 exit={{ scale: 0.5, opacity: 0 }}
                                 transition={{ type: 'spring', stiffness: 400, damping: 25 }}
                                 className={`flex items-center rounded-full text-sm font-semibold pl-3 ${
-                                    tag.isValid 
-                                    ? 'bg-indigo-100 dark:bg-indigo-500/20 text-indigo-800 dark:text-indigo-200' 
-                                    : 'bg-rose-100 dark:bg-rose-500/20 text-rose-800 dark:text-rose-200'
+                                    tag.isValid
+                                        ? 'bg-indigo-100 dark:bg-indigo-500/20 text-indigo-800 dark:text-indigo-200'
+                                        : 'bg-rose-100 dark:bg-rose-500/20 text-rose-800 dark:text-rose-200'
                                 }`}
                             >
                                 {!tag.isValid && <AlertTriangle size={14} className="mr-1.5 shrink-0" />}
                                 <span className="pr-2 py-1">{tag.displayValue}</span>
-                                <button 
-                                    onClick={() => onRemoveTag(tag.value)} 
+                                <button
+                                    onClick={(event) => {
+                                        event.stopPropagation();
+                                        onRemoveTag(tag.value);
+                                    }}
                                     className={`p-1.5 mr-1 rounded-full transition-colors ${
                                         tag.isValid
-                                        ? 'hover:bg-indigo-200 dark:hover:bg-indigo-500/30'
-                                        : 'hover:bg-rose-200 dark:hover:bg-rose-500/30'
+                                            ? 'hover:bg-indigo-200 dark:hover:bg-indigo-500/30'
+                                            : 'hover:bg-rose-200 dark:hover:bg-rose-500/30'
                                     }`}
-                                    aria-label={`Quitar filtro ${tag.displayValue}`}
+                                    aria-label={t(removeFilterLabelKey, { filter: tag.displayValue })}
                                 >
                                     <X size={14} />
                                 </button>
                             </motion.div>
                         ))}
                     </AnimatePresence>
-                    <input 
-                        type="text" 
+                    <input
+                        type="text"
                         value={inputValue}
-                        onChange={e => setInputValue(e.target.value)}
+                        onChange={(e) => setInputValue(e.target.value)}
                         onKeyDown={handleKeyDown}
-                        className={`flex-grow bg-transparent focus:outline-none p-2 min-w-[200px] text-lg font-bold ${isPlaceholderVisible ? 'caret-transparent' : ''}`}
-                        aria-label="Añadir filtro de búsqueda"
+                        className={`flex-grow bg-transparent focus:outline-none p-2 min-w-[200px] text-lg font-bold ${
+                            isPlaceholderVisible ? 'caret-transparent' : ''
+                        }`}
+                        role="combobox"
+                        aria-autocomplete="list"
+                        aria-expanded={suggestions.length > 0}
+                        aria-controls={SUGGESTION_LIST_ID}
+                        aria-activedescendant={
+                            activeSuggestionIndex >= 0 ? `${OPTION_ID_PREFIX}${activeSuggestionIndex}` : undefined
+                        }
+                        aria-label={addFilterAriaLabel}
                         autoComplete="off"
+                        data-testid="userlist-search-input"
                     />
                 </div>
             </div>
             <AutocompleteSuggestions
                 suggestions={suggestions}
                 activeSuggestionIndex={activeSuggestionIndex}
-                onSelectSuggestion={(suggestion) => handleAddTagAndReset(getFullName(suggestion))}
+                onSelectSuggestion={(suggestion) => handleAddTagAndReset(getDisplayName(suggestion))}
                 inputValue={inputValue}
+                suggestionListId={SUGGESTION_LIST_ID}
+                optionIdPrefix={OPTION_ID_PREFIX}
+                getDisplayName={getDisplayName}
             />
         </div>
     );

--- a/locales/en/translation.json
+++ b/locales/en/translation.json
@@ -112,6 +112,13 @@
     },
     "tag": {
       "removeLabel": "Remove tag"
+    },
+    "userListHeader": {
+      "placeholder": "Search (name, ID, role, grade: 5A)…",
+      "aria": {
+        "addFilter": "Add search filter",
+        "removeFilter": "Remove filter {{filter}}"
+      }
     }
   }
 }

--- a/locales/es/translation.json
+++ b/locales/es/translation.json
@@ -112,6 +112,13 @@
     },
     "tag": {
       "removeLabel": "Quitar etiqueta"
+    },
+    "userListHeader": {
+      "placeholder": "Buscar (nombre, DNI, rol, grado: 5A)…",
+      "aria": {
+        "addFilter": "Añadir filtro de búsqueda",
+        "removeFilter": "Quitar filtro {{filter}}"
+      }
     }
   }
 }

--- a/tests/components/UserListHeader.test.tsx
+++ b/tests/components/UserListHeader.test.tsx
@@ -1,0 +1,262 @@
+import React from 'react';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import userEvent from '@testing-library/user-event';
+import { render, screen, waitFor, within } from '../test-utils';
+import UserListHeader from '../../components/users/UserListHeader';
+import type { GenericUser, SearchTag, Student, Staff } from '../../types';
+
+const createStudent = (overrides: Partial<Student>): Student => ({
+  documentNumber: 'DOC-1',
+  studentCode: 'STU-1',
+  paternalLastName: 'Pérez',
+  maternalLastName: 'López',
+  names: 'Ana',
+  fullName: 'Ana Pérez',
+  gender: 'Mujer',
+  birthDate: '2010-01-01',
+  grade: '5',
+  section: 'A',
+  avatarUrl: 'https://example.com/avatar.png',
+  tutorIds: [],
+  enrollmentStatus: 'Matriculado',
+  status: 'Activo',
+  sede: 'Norte',
+  lastLogin: null,
+  condition: 'Regular',
+  tags: [],
+  averageGrade: 0,
+  attendancePercentage: 0,
+  tardinessCount: 0,
+  behaviorIncidents: 0,
+  academicRisk: false,
+  ...overrides,
+});
+
+const createStaff = (overrides: Partial<Staff>): Staff => ({
+  dni: 'DNI-1',
+  name: 'Default Staff',
+  area: 'Ciencia',
+  role: 'Docente',
+  avatarUrl: 'https://example.com/staff.png',
+  category: 'Docente',
+  status: 'Activo',
+  sede: 'Norte',
+  lastLogin: null,
+  tags: [],
+  ...overrides,
+});
+
+const students: Student[] = [
+  createStudent({
+    documentNumber: 'DOC-ALICE',
+    studentCode: 'STU-ALICE',
+    fullName: 'Alice Johnson',
+    names: 'Alice',
+    paternalLastName: 'Johnson',
+    maternalLastName: 'Stone',
+    avatarUrl: 'https://example.com/alice.png',
+  }),
+  createStudent({
+    documentNumber: 'DOC-ALICIA',
+    studentCode: 'STU-ALICIA',
+    fullName: 'Alícia Márquez',
+    names: 'Alícia',
+    paternalLastName: 'Márquez',
+    maternalLastName: 'Diaz',
+    avatarUrl: 'https://example.com/alicia.png',
+  }),
+];
+
+const staffMember: Staff = createStaff({
+  dni: 'DNI-ALBERT',
+  name: 'Albert Rivera',
+  avatarUrl: 'https://example.com/albert.png',
+});
+
+const allUsers: GenericUser[] = [...students, staffMember];
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('UserListHeader', () => {
+  it('renders placeholder text and combobox aria attributes via translations', () => {
+    const onAddTag = vi.fn();
+    const onRemoveTag = vi.fn();
+
+    render(
+      <UserListHeader tags={[]} allUsers={allUsers} onAddTag={onAddTag} onRemoveTag={onRemoveTag} />,
+    );
+
+    expect(screen.getByText('Search (name, ID, role, grade: 5A)…')).toBeInTheDocument();
+
+    const input = screen.getByTestId('userlist-search-input');
+    expect(input).toHaveAttribute('role', 'combobox');
+    expect(input).toHaveAttribute('aria-autocomplete', 'list');
+    expect(input).toHaveAttribute('aria-expanded', 'false');
+    expect(input).toHaveAttribute('aria-controls', 'user-suggestions-list');
+    expect(input).toHaveAttribute('aria-label', 'Add search filter');
+  });
+
+  it('respects minChars threshold before showing suggestions', async () => {
+    const onAddTag = vi.fn();
+    const onRemoveTag = vi.fn();
+    const user = userEvent.setup();
+
+    render(
+      <UserListHeader tags={[]} allUsers={allUsers} onAddTag={onAddTag} onRemoveTag={onRemoveTag} />,
+    );
+
+    const input = screen.getByTestId('userlist-search-input');
+
+    await user.type(input, 'a');
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('userlist-suggestions')).not.toBeInTheDocument();
+    });
+
+    await user.type(input, 'l');
+
+    await waitFor(() => {
+      expect(screen.getByTestId('userlist-suggestions')).toBeInTheDocument();
+    });
+
+    expect(input).toHaveAttribute('aria-expanded', 'true');
+  });
+
+  it('limits rendered suggestions based on suggestionLimit', async () => {
+    const onAddTag = vi.fn();
+    const onRemoveTag = vi.fn();
+    const user = userEvent.setup();
+
+    render(
+      <UserListHeader
+        tags={[]}
+        allUsers={allUsers}
+        onAddTag={onAddTag}
+        onRemoveTag={onRemoveTag}
+        suggestionLimit={1}
+      />,
+    );
+
+    const input = screen.getByTestId('userlist-search-input');
+    await user.type(input, 'al');
+
+    const list = await screen.findByTestId('userlist-suggestions');
+    const options = within(list).getAllByRole('option');
+    expect(options).toHaveLength(1);
+  });
+
+  it('hides suggestions when the grade pattern matches the input', async () => {
+    const onAddTag = vi.fn();
+    const onRemoveTag = vi.fn();
+    const user = userEvent.setup();
+
+    render(
+      <UserListHeader tags={[]} allUsers={allUsers} onAddTag={onAddTag} onRemoveTag={onRemoveTag} />,
+    );
+
+    const input = screen.getByTestId('userlist-search-input');
+    await user.type(input, '5A');
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('userlist-suggestions')).not.toBeInTheDocument();
+    });
+  });
+
+  it('supports keyboard navigation, selection, and escape handling', async () => {
+    const onAddTag = vi.fn();
+    const onRemoveTag = vi.fn();
+    const user = userEvent.setup();
+
+    render(
+      <UserListHeader tags={[]} allUsers={allUsers} onAddTag={onAddTag} onRemoveTag={onRemoveTag} />,
+    );
+
+    const input = screen.getByTestId('userlist-search-input');
+    await user.type(input, 'ali');
+
+    const list = await screen.findByTestId('userlist-suggestions');
+    const options = within(list).getAllByRole('option');
+
+    await user.keyboard('{ArrowDown}');
+
+    expect(input).toHaveAttribute('aria-activedescendant', 'user-suggestion-0');
+    expect(options[0]).toHaveAttribute('aria-selected', 'true');
+
+    await user.keyboard('{Enter}');
+
+    expect(onAddTag).toHaveBeenCalledWith('Alice Johnson');
+    expect(input).toHaveValue('');
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('userlist-suggestions')).not.toBeInTheDocument();
+    });
+
+    await user.type(input, 'ali');
+    await screen.findByTestId('userlist-suggestions');
+    await user.keyboard('{Escape}');
+
+    expect(input).toHaveValue('');
+    await waitFor(() => {
+      expect(screen.queryByTestId('userlist-suggestions')).not.toBeInTheDocument();
+    });
+  });
+
+  it('uses custom getDisplayName when provided', async () => {
+    const onAddTag = vi.fn();
+    const onRemoveTag = vi.fn();
+    const user = userEvent.setup();
+    const customGetDisplayName = (userEntity: GenericUser) =>
+      userEntity === students[0] ? 'Alpha' : 'Omega';
+
+    render(
+      <UserListHeader
+        tags={[]}
+        allUsers={allUsers}
+        onAddTag={onAddTag}
+        onRemoveTag={onRemoveTag}
+        getDisplayName={customGetDisplayName}
+      />,
+    );
+
+    const input = screen.getByTestId('userlist-search-input');
+    await user.type(input, 'al');
+
+    const list = await screen.findByTestId('userlist-suggestions');
+    const options = within(list).getAllByRole('option');
+    expect(options[0]).toHaveTextContent('Alpha');
+
+    await user.keyboard('{ArrowDown}');
+    await user.keyboard('{Enter}');
+
+    expect(onAddTag).toHaveBeenCalledWith('Alpha');
+  });
+
+  it('stops remove button propagation and uses translated aria-label', async () => {
+    const onAddTag = vi.fn();
+    const onRemoveTag = vi.fn();
+    const parentClick = vi.fn();
+    const user = userEvent.setup();
+    const tags: SearchTag[] = [
+      {
+        value: 'Test Filter',
+        displayValue: 'Test Filter',
+        type: 'keyword',
+        isValid: true,
+      },
+    ];
+
+    render(
+      <div onClick={parentClick}>
+        <UserListHeader tags={tags} allUsers={allUsers} onAddTag={onAddTag} onRemoveTag={onRemoveTag} />
+      </div>,
+    );
+
+    const removeButton = screen.getByRole('button', { name: 'Remove filter Test Filter' });
+    await user.click(removeButton);
+
+    expect(onRemoveTag).toHaveBeenCalledWith('Test Filter');
+    expect(parentClick).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- parameterize the user list header search input with i18n-aware labels, configurable thresholds, and full combobox semantics
- update autocomplete suggestions to expose listbox roles, deterministic option ids, and resilient highlight handling
- add locale strings and Vitest coverage for keyboard navigation, filtering rules, and accessibility labels

## Testing
- npx vitest run tests/components/UserListHeader.test.tsx

------
https://chatgpt.com/codex/tasks/task_b_68e0c2bd983083298d0fb6a1bed9bada